### PR TITLE
Precompute progress styles for gritos view

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,13 +418,21 @@ app.get('/', (req, res) => {
 
 app.get('/gritos', (req, res) => {
   const { ranking, totalVotes, maxVotes } = getRankingMetrics();
+  const rankingWithProgress = ranking.map((grito) => {
+    const progressPercent = maxVotes ? Math.round((grito.votos / maxVotes) * 100) : 0;
+    return {
+      ...grito,
+      progressPercent,
+      progressStyle: `width: ${progressPercent}%;`
+    };
+  });
   res.render('gritos', {
     activePage: 'gritos',
-    gritos: ranking,
+    gritos: rankingWithProgress,
     totalVotes,
     maxVotes,
-    highlight: ranking[0] || null,
-    secondaryHighlights: ranking.slice(1, 3)
+    highlight: rankingWithProgress[0] || null,
+    secondaryHighlights: rankingWithProgress.slice(1, 3)
   });
 });
 

--- a/views/gritos.ejs
+++ b/views/gritos.ejs
@@ -97,16 +97,9 @@
             </div>
             <p class="grito-card__description"><%= grito.descripcion %></p>
             <div class="grito-card__stats">
-
-                <div class="progress" role="img" aria-label="<%= grito.votos %> votos">
-                  <% const progreso = maxVotes ? Math.round((grito.votos / maxVotes) * 100) : 0; %>
-                  <div class="progress__bar" style="width: <%= progreso %>%;"></div>
-                </div>
-
               <div class="progress" role="img" aria-label="<%= grito.votos %> votos">
-                <div class="progress__bar" style="width: <%= maxVotes ? Math.round((grito.votos / maxVotes) * 100) : 0 %>%"></div>
+                <div class="progress__bar" style="<%- grito.progressStyle %>"></div>
               </div>
-
               <span class="grito-card__votes"><span class="grito-card__votes-value"><%= grito.votos %></span> voto<%= grito.votos === 1 ? '' : 's' %></span>
             </div>
             <form class="vote-form" action="/gritos/votar/<%= grito.id %>" method="POST">


### PR DESCRIPTION
## Summary
- precompute a width style for each grito entry before rendering the ranking
- simplify the gritos view to use the precomputed style and remove duplicate progress markup

## Testing
- node index.js

------
https://chatgpt.com/codex/tasks/task_e_68c8ed6875e4832db4f9644af8a89bce